### PR TITLE
Updated files for release 1.0.25

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2htpdtor (1.0.25) trusty; urgency=low
+
+  * Fixed destructing code for corresponding to SIOF, etc
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Wed, 17 Oct 2018 19:12:19 +0900
+
 k2htpdtor (1.0.24) trusty; urgency=low
 
   * Revert subdir-objects automake option in src directory

--- a/buildutils/control.in
+++ b/buildutils/control.in
@@ -2,7 +2,7 @@ Source: @PACKAGE_NAME@
 Section: libs
 Priority: extra
 Maintainer: @DEV_NAME@ <@DEV_EMAIL@>
-Build-Depends: debhelper (>= 9), autotools-dev, k2hash-dev (>= 1.0.61), libfullock-dev (>= 1.0.28), chmpx-dev (>= 1.0.62)
+Build-Depends: debhelper (>= 9), autotools-dev, k2hash-dev (>= 1.0.63), libfullock-dev (>= 1.0.30), chmpx-dev (>= 1.0.63)
 Standards-Version: 3.9.5
 Homepage: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Vcs-Git: git://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@.git
@@ -11,6 +11,6 @@ Vcs-Browser: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Package: @PACKAGE_NAME@
 Section: libs
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${misc:Pre-Depends}, k2hash (>= 1.0.61), libfullock (>= 1.0.28), chmpx (>= 1.0.62)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${misc:Pre-Depends}, k2hash (>= 1.0.63), libfullock (>= 1.0.30), chmpx (>= 1.0.63)
 Description: @SHORTDESC@
 @DEBLONGDESC@

--- a/buildutils/k2htpdtor.spec.in
+++ b/buildutils/k2htpdtor.spec.in
@@ -46,8 +46,9 @@ License: @PKGLICENSE@
 Group: Applications/Databases
 URL: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@
 Source0: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@/archive/%{gittag}/%{name}-%{version}.tar.gz
+Requires: libfullock%{?_isa} >= 1.0.30, k2hash%{?_isa} >= 1.0.63, chmpx%{?_isa} >= 1.0.63
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-BuildRequires: git-core gcc-c++ make libtool libfullock-devel%{?_isa} >= 1.0.28, k2hash-devel%{?_isa} >= 1.0.61, chmpx-devel%{?_isa} >= 1.0.62
+BuildRequires: git-core gcc-c++ make libtool libfullock-devel%{?_isa} >= 1.0.30, k2hash-devel%{?_isa} >= 1.0.63, chmpx-devel%{?_isa} >= 1.0.63
 Prefix: %{_prefix}
 
 %description

--- a/configure.ac
+++ b/configure.ac
@@ -130,9 +130,9 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.28], [], [AC_MSG_ERROR(not found libfullock package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.61], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.62], [], [AC_MSG_ERROR(not found chmpx package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.30], [], [AC_MSG_ERROR(not found libfullock package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.63], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.63], [], [AC_MSG_ERROR(not found chmpx package)])])
 
 #
 # CFLAGS/CXXFLAGS


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.24 to 1.0.25

#### 1.0.25
- Fixed destructing code for corresponding to SIOF, etc
  Fixed segmentation Fault in destructor code again.
  Since the modification of v1.0.61( avoid static object initialization order problem(SIOF) ), rarely a segmantation fault occurred when the single object of std::map etc was destroyed.
  And added requires keyword in spec file for dependent packages.