### PR TITLE
Added check using cppcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,19 @@
 SUBDIRS=lib src docs tests buildutils
 EXTRA_DIST=RELEASE_VERSION
 
+CPPCHECK_CMD=	cppcheck
+CPPCHECK_OPT=	--quiet \
+				--error-exitcode=1 \
+				--inline-suppr \
+				-j 4 \
+				--std=c++03 \
+				--xml \
+				--enable=warning,style,information,missingInclude
+CPPCHECK_IGN=
+
+cppcheck:
+	$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)
+
 #
 # VIM modelines
 #

--- a/buildutils/travis_builder.sh
+++ b/buildutils/travis_builder.sh
@@ -321,10 +321,27 @@ else
 	#
 	# Using RHSCL because centos has older ruby
 	#
-	run_cmd yum install -y -qq centos-release-scl
-	run_cmd yum install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
+	run_cmd ${INSTALLER_BIN} install -y -qq centos-release-scl
+	run_cmd ${INSTALLER_BIN} install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
 	source /opt/rh/rh-ruby23/enable
 	run_cmd ${GEM_BIN} install rubocop package_cloud
+fi
+
+#
+# For cppcheck
+#
+if [ ${IS_CENTOS} -eq 1 ]; then
+	#
+	# For CentOS, it need to allow EPEL(with setting disable)
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq epel-release
+	run_cmd yum-config-manager --disable epel
+	run_cmd ${INSTALLER_BIN} --enablerepo=epel install -y -qq cppcheck
+else
+	#
+	# Fedora, Ubuntu...
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq cppcheck
 fi
 
 #
@@ -337,6 +354,7 @@ SRCTOP="/tmp/${TMPSRCTOP}"
 run_cmd cd ${SRCTOP}
 run_cmd ./autogen.sh
 run_cmd ./configure --prefix=/usr ${CONFIGUREOPT}
+run_cmd make cppcheck
 run_cmd make
 run_cmd make check
 

--- a/lib/k2htpdtorman.cc
+++ b/lib/k2htpdtorman.cc
@@ -146,6 +146,7 @@ static unsigned char* cvt_escape_sequence(const char* pstr, size_t& length, bool
 				if('x' == pstr[2]){
 					unsigned char	byBuff	= 0x00;
 					int				pos;
+					// cppcheck-suppress arrayIndexThenCheck
 					for(pos = 3; '\0' != pstr[pos] && pos < 5; pos++){
 						if('0' <= pstr[pos] && pstr[pos] <= '9'){
 							byBuff  = byBuff * 16;
@@ -166,6 +167,7 @@ static unsigned char* cvt_escape_sequence(const char* pstr, size_t& length, bool
 				}else if(0 != isdigit(pstr[2])){
 					unsigned char	byBuff	= 0x00;
 					int				pos;
+					// cppcheck-suppress arrayIndexThenCheck
 					for(pos = 2; '\0' != pstr[pos] && pos < 5; pos++){
 						if('0' <= pstr[pos] && pstr[pos] <= '9'){
 							byBuff  = byBuff * 8;
@@ -503,6 +505,8 @@ bool K2HtpDtorManager::LoadConfigrationYaml(const char* config, string& chmpxcon
 		// open configuration file
 		if(NULL == (fp = fopen(config, "r"))){
 			ERR_K2HPRN("Could not open configuration file(%s). errno = %d", config, errno);
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress resourceLeak
 			return false;
 		}
 		// set file to parser
@@ -982,8 +986,7 @@ bool K2HtpDtorManager::Remove(k2h_h k2hhandle)
 		// There is no k2hhandle.
 		WAN_K2HPRN("K2HTPDTOR already does not have k2hash handle(0x%016" PRIx64 ").", k2hhandle);
 	}else{
-		PDTORINFO	pdtor	= dtormap[k2hhandle];
-		pdtor->remove_this	= true;
+		PDTORINFO	pdtor		= dtormap[k2hhandle];
 		if(pdtor){
 			pdtor->remove_this	= true;
 		}

--- a/lib/k2htpdtorman.h
+++ b/lib/k2htpdtorman.h
@@ -64,6 +64,7 @@ inline bool find_dtorpbylst(dtorpbylst_t& pbylst, const unsigned char* pbin, siz
 	if(!pbin || 0 == length){
 		return false;
 	}
+	// cppcheck-suppress postfixOperator
 	for(dtorpbylst_t::const_iterator iter = pbylst.begin(); iter != pbylst.end(); iter++){
 		if(length < (*iter)->length){
 			continue;

--- a/src/k2htpdtorsvr.cc
+++ b/src/k2htpdtorsvr.cc
@@ -171,6 +171,8 @@ int main(int argc, char** argv)
 	dtorparam_t	params;
 
 	// Parse parameter
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress stlSize
 	if(!ParamParser(argc, argv, params) || 0 == params.size()){
 		PrintUsage(argv[0]);
 		exit(EXIT_FAILURE);

--- a/src/k2htpdtorsvrparser.cc
+++ b/src/k2htpdtorsvrparser.cc
@@ -763,6 +763,8 @@ static bool ParseK2htpdtorsvrYaml(const char* config, PK2HTPDTORSVRINFO pInfo, b
 		// open configuration file
 		if(NULL == (fp = fopen(config, "r"))){
 			ERR_K2HPRN("Could not open configuration file(%s). errno = %d", config, errno);
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress resourceLeak
 			return false;
 		}
 		// set file to parser


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Added cppcheck
We made use of cppcheck.  
cppcheck will automatically run on TravisCI.  
If you want to run it manually, please use `make cppcheck`.  

In this PR, we corrected errors etc. detected by cppcheck.

#### NOTE
cppcheck depends on the OS of the build environment, and different versions are used for each.  
This PR is trying to eliminate this difference.

