### PR TITLE
Updated files for release 1.0.29

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2htpdtor (1.0.29) trusty; urgency=low
+
+  * Fixed codes for cppcheck 1.87 - #21
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Tue, 12 Mar 2019 18:48:50 +0900
+
 k2htpdtor (1.0.28) trusty; urgency=low
 
   * Fixed misspelling, and etc - #18


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.28 to 1.0.29
- Fixed codes for cppcheck 1.87 - #21
