### PR TITLE
Updated files for release 1.0.32

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2htpdtor (1.0.32) trusty; urgency=low
+
+  * Fixed centos8 build and removed centos6 build - #29
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Thu, 17 Dec 2020 12:58:43 +0900
+
 k2htpdtor (1.0.31) trusty; urgency=low
 
   * Switched Travis CI to Github actions and extended supported OS - #27


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.31 to 1.0.32
- Fixed centos8 build and removed centos6 build - #29


