### PR TITLE
Drops Fedora28 and CentOS6.x from our support OS

### DIFF
--- a/build.md
+++ b/build.md
@@ -44,7 +44,7 @@ This section instructs how to install each dependent library and the header file
 
 Note: Skip reading this section if you have installed each dependent library and the header files from [GitHub](https://github.com/yahoojapan) in the previous section.
 
-For DebianStretch or Ubuntu(Bionic Beaver) users, follow the steps below:
+For recent Debian-based Linux distributions users, follow the steps below:
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -55,7 +55,18 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-For Fedora28 or CentOS7.x(6.x) users, follow the steps below:
+For users who use supported Fedora other than latest version, follow the steps below:
+```bash
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel k2hash-devel chmpx-devel -y
+$ sudo dnf install git -y
+```
+
+For other recent RPM-based Linux distributions users, follow the steps below:
 ```bash
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/buildja.md
+++ b/buildja.md
@@ -44,7 +44,7 @@ next_string:
 
 注：前のセクションで各依存ライブラリと[GitHub](https://github.com/yahoojapan)からのヘッダーファイルをインストールした場合は、このセクションを読み飛ばしてください。
 
-DebianStretchまたはUbuntu（Bionic Beaver）をお使いの場合は、以下の手順に従ってください。
+最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -55,7 +55,18 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-Fedora28またはCentOS7.x（6.x）ユーザーの場合は、以下の手順に従ってください。
+Fedoraの利用者は、以下の手順に従ってください。
+```bash
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel k2hash-devel chmpx-devel -y
+$ sudo dnf install git -y
+```
+
+その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```bash
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/usage.md
+++ b/usage.md
@@ -82,7 +82,7 @@ The **K2HTPDTOR** publishes [packages](https://packagecloud.io/app/antpickax/sta
 The package of the **K2HTPDTOR** is released in the form of Debian package, RPM package.  
 Since the installation method differs depending on your OS, please check the following procedure and install it.  
 
-##### Debian(Stretch) / Ubuntu(Bionic Beaver)
+##### For recent Debian-based Linux distributions users, follow the steps below:
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -90,7 +90,15 @@ $ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.d
 $ sudo apt-get install k2htpdtor chmpx
 ```
 
-##### Fedora28 / CentOS7.x(6.x)
+##### For users who use supported Fedora other than latest version, follow the steps below:
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install k2htpdtor chmpx
+```
+
+##### For other recent RPM-based Linux distributions users, follow the steps below:
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/usageja.md
+++ b/usageja.md
@@ -83,7 +83,7 @@ K2HTPDTORおよびK2HTPDTORSVRをビルドした後で、簡単な動作確認�
 **K2HTPDTOR** のパッケージは、Debianパッケージ、RPMパッケージの形式で公開しています。  
 お使いのOSによりインストール方法が異なりますので、以下の手順を確認してインストールしてください。  
 
-##### Debian(Stretch) / Ubuntu(Bionic Beaver)
+##### 最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -91,7 +91,15 @@ $ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.d
 $ sudo apt-get install k2htpdtor chmpx
 ```
 
-##### Fedora28 / CentOS7.x(6.x)
+##### Fedoraの利用者は、以下の手順に従ってください。
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install k2htpdtor
+```
+
+##### その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR removes unsupported OS descrptions from manuals.