### PR TITLE
Updated files for release 1.0.35

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2htpdtor (1.0.35) trusty; urgency=low
+
+  * Bumpup for updating the base Docker image becase of CHMPX updated
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Mon, 27 Sep 2021 11:14:33 +0900
+
 k2htpdtor (1.0.34) trusty; urgency=low
 
   * Fixed Dockerfile template for calling ldconfig - #35


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.34 to 1.0.35
- Bumpup for updating the base Docker image becase of CHMPX updated
